### PR TITLE
Memoize colors palette

### DIFF
--- a/lib/heatmap_builder/builder.rb
+++ b/lib/heatmap_builder/builder.rb
@@ -85,5 +85,16 @@ module HeatmapBuilder
     def default_options
       DEFAULT_OPTIONS
     end
+
+    def color_palette
+      @color_palette ||= begin
+        colors_option = options[:colors]
+        if colors_option.is_a?(Hash)
+          generate_color_palette(colors_option[:from], colors_option[:to], colors_option[:steps])
+        else
+          colors_option
+        end
+      end
+    end
   end
 end

--- a/lib/heatmap_builder/calendar_heatmap_builder.rb
+++ b/lib/heatmap_builder/calendar_heatmap_builder.rb
@@ -54,13 +54,8 @@ module HeatmapBuilder
     def validate_options!
       super
 
-      if scores
-        raise Error, "scores must be a hash" unless scores.is_a?(Hash)
-      end
-
-      if values
-        raise Error, "values must be a hash" unless values.is_a?(Hash)
-      end
+      raise Error, "scores must be a hash" if scores && !scores.is_a?(Hash)
+      raise Error, "values must be a hash" if values && !values.is_a?(Hash)
 
       unless VALID_START_DAYS.include?(options[:start_of_week])
         raise Error, "start_of_week must be one of: #{VALID_START_DAYS.join(", ")}"

--- a/lib/heatmap_builder/calendar_heatmap_builder.rb
+++ b/lib/heatmap_builder/calendar_heatmap_builder.rb
@@ -136,7 +136,7 @@ module HeatmapBuilder
     end
 
     def cell_svg(score, x, y, inactive = false)
-      color = score_to_color(score, colors: options[:colors])
+      color = score_to_color(score, colors: color_palette)
 
       if inactive
         color = make_color_inactive(color)

--- a/lib/heatmap_builder/linear_heatmap_builder.rb
+++ b/lib/heatmap_builder/linear_heatmap_builder.rb
@@ -43,7 +43,7 @@ module HeatmapBuilder
       x = index * (options[:cell_size] + options[:cell_spacing])
       y = 0
 
-      color = score_to_color(score, colors: options[:colors])
+      color = score_to_color(score, colors: color_palette)
 
       colored_rect = svg_rect(
         x: x, y: y,


### PR DESCRIPTION
When using colors: `{ from: "#color1", to: "#color2", steps: 5 }`, the palette generation (with relatively complex math) was happening for every single cell.

The fix adds a `color_palette` method in the `Builder` class that caches once-generated palette.