### PR TITLE
Add YARD comments to public API and update options description in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ HeatmapBuilder.build_linear(
 
 ![Linear Rounded Corners](examples/linear_rounded_corners.svg)
 
-The `corner_radius` value must be between 0 (square corners) and `floor(cell_size/2)`. Maximum radius value render circular cells:
+The `corner_radius` value must be between 0 (square corners) and `floor(cell_size/2)`. Values outside this range are automatically clamped to the valid range (negative values become 0, values exceeding the maximum become `floor(cell_size/2)`). Maximum radius values render circular cells:
 
 ```ruby
 # Linear heatmap with max radius rounded corners - circular cells

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 - `font_size` - Font size for score text in pixels. Defaults to 8.
 - `border_width` - Border width around each cell in pixels. Defaults to 1.
 - `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
-- `text_color` - Color of score text as a hex string. Defaults to `"#000000"`.
+- `text_color` - Color of score text as a hex string. Defaults to `"#000000"` (black).
 
 **Color options:**
 
@@ -119,7 +119,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 - `font_size` - Font size for labels in pixels. Defaults to 8.
 - `border_width` - Border width around each cell in pixels. Defaults to 1.
 - `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
-- `text_color` - Color of label text as a hex string. Defaults to `"#000000"`.
+- `text_color` - Color of label text as a hex string. Defaults to `"#000000"` (black).
 
 **Color options:**
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Custom scoring logic - linear distribution example:
 
 ```ruby
 linear_formula = ->(value:, index:, min:, max:, max_score:) {
-  ((value - min) / (max - min) * max_score).floor
+  ((value - min) / (max - min) * max_score).round
 }
 
 svg = HeatmapBuilder.build_linear(
@@ -209,7 +209,7 @@ logarithmic_formula = ->(value:, index:, min:, max:, max_score:) {
   log_min = Math.log10(min)
   log_max = Math.log10(max)
 
-  ((log_value - log_min) / (log_max - log_min) * max_score).floor.clamp(0, max_score)
+  ((log_value - log_min) / (log_max - log_min) * max_score).round.clamp(0, max_score)
 }
 
 svg = HeatmapBuilder.build_linear(

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 - `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
 - `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
-- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `index:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `index:`, `min:`, `max:`, `max_score:` parameters and must return an integer between 0 and `max_score`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
 
 **Appearance options:**
 
@@ -110,7 +110,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 - `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
 - `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
-- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `date:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `date:`, `min:`, `max:`, `max_score:` parameters and must return an integer between 0 and `max_score`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
 
 **Appearance options:**
 
@@ -182,15 +182,15 @@ The callable receives these parameters:
 - `index:` or `date:` - The position in the data (linear heatmaps use `index:`, calendar heatmaps use `date:`)
 - `min:` - The minimum boundary value
 - `max:` - The maximum boundary value
-- `num_scores:` - The number of available scores (length of color palette)
+- `max_score:` - The maximum valid score (color palette length minus 1)
 
-The function must return an integer between 0 and `num_scores - 1`.
+The function must return an integer between 0 and `max_score`.
 
 Custom scoring logic - linear distribution example:
 
 ```ruby
-linear_formula = ->(value:, index:, min:, max:, num_scores:) {
-  ((value - min) / (max - min) * (num_scores - 1)).floor
+linear_formula = ->(value:, index:, min:, max:, max_score:) {
+  ((value - min) / (max - min) * max_score).floor
 }
 
 svg = HeatmapBuilder.build_linear(
@@ -202,14 +202,14 @@ svg = HeatmapBuilder.build_linear(
 Logarithmic scale for data with wide range (e.g., 1 to 10000):
 
 ```ruby
-logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {
+logarithmic_formula = ->(value:, index:, min:, max:, max_score:) {
   return 0 if value <= 0 || min <= 0
 
   log_value = Math.log10(value)
   log_min = Math.log10(min)
   log_max = Math.log10(max)
 
-  ((log_value - log_min) / (log_max - log_min) * (num_scores - 1)).floor.clamp(0, num_scores - 1)
+  ((log_value - log_min) / (log_max - log_min) * max_score).floor.clamp(0, max_score)
 }
 
 svg = HeatmapBuilder.build_linear(

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 - `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
 - `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
-- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `index:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores) for details.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `index:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
 
 **Appearance options:**
 
@@ -110,7 +110,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 - `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
 - `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
-- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `date:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores) for details.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `date:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Custom Scoring Logic](#custom-scoring-logic) for details.
 
 **Appearance options:**
 
@@ -173,19 +173,28 @@ The builder will automatically:
 - Clamp values outside the boundaries
 - Handle nil values by treating them as the minimum boundary
 
-You can also provide a custom value-to-score conversion function:
+### Custom Scoring Logic
+
+By default, values are mapped to scores using linear distribution. You can provide a custom value-to-score conversion function for different behaviors like logarithmic scales, exponential curves, or custom thresholds.
+
+The callable receives these parameters:
+- `value:` - The current value being converted
+- `index:` or `date:` - The position in the data (linear heatmaps use `index:`, calendar heatmaps use `date:`)
+- `min:` - The minimum boundary value
+- `max:` - The maximum boundary value
+- `num_scores:` - The number of available scores (length of color palette)
+
+The function must return an integer between 0 and `num_scores - 1`.
 
 ```ruby
-# Custom scoring logic - linear distribution
-custom_formula = ->(value:, index:, min:, max:, num_scores:) {
-  # Your custom logic here
-  # Must return integer between 0 and num_scores-1
+# Linear distribution (this is the default behavior)
+linear_formula = ->(value:, index:, min:, max:, num_scores:) {
   ((value - min) / (max - min) * (num_scores - 1)).floor
 }
 
 svg = HeatmapBuilder.build_linear(
   values: [10, 20, 30],
-  value_to_score: custom_formula
+  value_to_score: linear_formula
 )
 
 # Logarithmic scale for data with wide range (e.g., 1 to 10000)
@@ -204,8 +213,6 @@ svg = HeatmapBuilder.build_linear(
   value_to_score: logarithmic_formula
 )
 ```
-
-For calendar heatmaps, the callable receives `date:` parameter instead of `index:`.
 
 ### Predefined Color Palettes
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,9 @@ The callable receives these parameters:
 
 The function must return an integer between 0 and `num_scores - 1`.
 
-**Custom scoring logic - linear distribution example:**
+Custom scoring logic - linear distribution example:
 
 ```ruby
-# Linear distribution (this is the default behavior)
 linear_formula = ->(value:, index:, min:, max:, num_scores:) {
   ((value - min) / (max - min) * (num_scores - 1)).floor
 }
@@ -200,7 +199,7 @@ svg = HeatmapBuilder.build_linear(
 )
 ```
 
-**Logarithmic scale for data with wide range (e.g., 1 to 10000):**
+Logarithmic scale for data with wide range (e.g., 1 to 10000):
 
 ```ruby
 logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {

--- a/README.md
+++ b/README.md
@@ -69,75 +69,6 @@ svg = HeatmapBuilder.build_calendar(scores: scores_by_date)
 
 ![GitHub-style Calendar](examples/calendar_github_style.svg)
 
-### Using Raw Values Instead of Scores
-
-A **score** is an integer (0 to N-1) that maps directly to a color in your palette. For example, with 5 colors, valid scores are 0-4.
-
-Instead of pre-calculating scores, you can provide raw numeric values (like 45.2, 78, 1000) and let the builder automatically map them to scores using linear distribution:
-
-```ruby
-# Linear heatmap with automatic score calculation
-values = [10, 25, 50, 75, 100]
-svg = HeatmapBuilder.build_linear(
-  values: values,
-  value_min: 0,    # Optional: explicitly set minimum (defaults to actual min)
-  value_max: 100   # Optional: explicitly set maximum (defaults to actual max)
-)
-
-# Calendar heatmap with automatic score calculation
-values_by_date = {
-  Date.new(2024, 1, 1) => 45.2,
-  Date.new(2024, 1, 2) => 78.5,
-  Date.new(2024, 1, 3) => 12.0
-}
-
-svg = HeatmapBuilder.build_calendar(
-  values: values_by_date,
-  value_min: 0,
-  value_max: 100
-)
-```
-
-The builder will automatically:
-- Calculate min/max boundaries from your data if not specified
-- Map values to color scores using linear distribution
-- Clamp values outside the boundaries
-- Handle nil values by treating them as the minimum boundary
-
-You can also provide a custom value-to-score conversion function:
-
-```ruby
-# Custom scoring logic - linear distribution
-custom_formula = ->(value:, index:, min:, max:, num_scores:) {
-  # Your custom logic here
-  # Must return integer between 0 and num_scores-1
-  ((value - min) / (max - min) * (num_scores - 1)).floor
-}
-
-svg = HeatmapBuilder.build_linear(
-  values: [10, 20, 30],
-  value_to_score: custom_formula
-)
-
-# Logarithmic scale for data with wide range (e.g., 1 to 10000)
-logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {
-  return 0 if value <= 0 || min <= 0
-
-  log_value = Math.log10(value)
-  log_min = Math.log10(min)
-  log_max = Math.log10(max)
-
-  ((log_value - log_min) / (log_max - log_min) * (num_scores - 1)).floor.clamp(0, num_scores - 1)
-}
-
-svg = HeatmapBuilder.build_linear(
-  values: [1, 10, 100, 1000, 10000],
-  value_to_score: logarithmic_formula
-)
-```
-
-For calendar heatmaps, the callable receives `date:` parameter instead of `index:`.
-
 ### Linear Heatmap Options
 
 You must provide either `scores:` or `values:` (but not both). All other options are optional keyword arguments with sensible defaults.
@@ -206,6 +137,75 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 - `day_labels` - Array of day abbreviations starting from Sunday (7 elements). Defaults to `%w[S M T W T F S]`. See [I18n](#i18n).
 - `month_labels` - Array of month abbreviations from January to December (12 elements). Defaults to `%w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec]`. See [I18n](#i18n).
+
+### Using Raw Values Instead of Scores
+
+A **score** is an integer (0 to N-1) that maps directly to a color in your palette. For example, with 5 colors, valid scores are 0-4.
+
+Instead of pre-calculating scores, you can provide raw numeric values (like 45.2, 78, 1000) and let the builder automatically map them to scores using linear distribution:
+
+```ruby
+# Linear heatmap with automatic score calculation
+values = [10, 25, 50, 75, 100]
+svg = HeatmapBuilder.build_linear(
+  values: values,
+  value_min: 0,    # Optional: explicitly set minimum (defaults to actual min)
+  value_max: 100   # Optional: explicitly set maximum (defaults to actual max)
+)
+
+# Calendar heatmap with automatic score calculation
+values_by_date = {
+  Date.new(2024, 1, 1) => 45.2,
+  Date.new(2024, 1, 2) => 78.5,
+  Date.new(2024, 1, 3) => 12.0
+}
+
+svg = HeatmapBuilder.build_calendar(
+  values: values_by_date,
+  value_min: 0,
+  value_max: 100
+)
+```
+
+The builder will automatically:
+- Calculate min/max boundaries from your data if not specified
+- Map values to color scores using linear distribution
+- Clamp values outside the boundaries
+- Handle nil values by treating them as the minimum boundary
+
+You can also provide a custom value-to-score conversion function:
+
+```ruby
+# Custom scoring logic - linear distribution
+custom_formula = ->(value:, index:, min:, max:, num_scores:) {
+  # Your custom logic here
+  # Must return integer between 0 and num_scores-1
+  ((value - min) / (max - min) * (num_scores - 1)).floor
+}
+
+svg = HeatmapBuilder.build_linear(
+  values: [10, 20, 30],
+  value_to_score: custom_formula
+)
+
+# Logarithmic scale for data with wide range (e.g., 1 to 10000)
+logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {
+  return 0 if value <= 0 || min <= 0
+
+  log_value = Math.log10(value)
+  log_min = Math.log10(min)
+  log_max = Math.log10(max)
+
+  ((log_value - log_min) / (log_max - log_min) * (num_scores - 1)).floor.clamp(0, num_scores - 1)
+}
+
+svg = HeatmapBuilder.build_linear(
+  values: [1, 10, 100, 1000, 10000],
+  value_to_score: logarithmic_formula
+)
+```
+
+For calendar heatmaps, the callable receives `date:` parameter instead of `index:`.
 
 ### Predefined Color Palettes
 

--- a/README.md
+++ b/README.md
@@ -124,81 +124,72 @@ For calendar heatmaps, the callable receives `date:` parameter instead of `index
 
 ### Linear Heatmap Options
 
-All options have defaults and are optional:
+You must provide either `scores:` or `values:` (but not both). All other options are optional keyword arguments with sensible defaults.
 
-```ruby
-HeatmapBuilder.build_linear(
-  # Data - provide either scores OR values (not both)
-  scores: [0, 1, 2, 3, 4],    # Pre-calculated scores (0 to num_colors-1)
-  # OR
-  values: [10, 25, 50, 75, 100],  # Arbitrary numeric values
+**Data options:**
 
-  # Value-to-Score Options (only used with values:)
-  value_min: 0,               # Minimum boundary (defaults to actual min)
-  value_max: 100,             # Maximum boundary (defaults to actual max)
-  value_to_score: ->(value:, index:, min:, max:, num_scores:) { ... },  # Custom conversion function
+- `scores` - Array of pre-calculated scores (integers from 0 to number of colors minus 1). Required if `values` is not provided.
+- `values` - Array of arbitrary numeric values to be automatically mapped to scores. Required if `scores` is not provided. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores).
 
-  # Appearance
-  cell_size: 10,              # Size of each square in pixels
-  cell_spacing: 1,            # Space between squares in pixels
-  font_size: 8,               # Font size for score text
-  border_width: 1,            # Border width around each cell
-  corner_radius: 0,           # Corner radius for rounded cells (0 for square, max: floor(cell_size/2))
-  text_color: "#000000",      # Color of score text
+**Value-to-score conversion options** (only used with `values:`):
 
-  # Colors - can be an array of hex colors or a hash for OKLCH interpolation
-  colors: HeatmapBuilder::GITHUB_GREEN,  # Use predefined palette
-  # OR manually define color array:
-  # colors: %w[#ebedf0 #9be9a8 #40c463 #30a14e #216e39]
-  # OR use OKLCH interpolation:
-  # colors: { from: "#ebedf0", to: "#216e39", steps: 5 }
-)
-```
+- `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
+- `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `index:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores) for details.
+
+**Appearance options:**
+
+- `cell_size` - Size of each square in pixels. Defaults to 10.
+- `cell_spacing` - Space between squares in pixels. Defaults to 1.
+- `font_size` - Font size for score text in pixels. Defaults to 8.
+- `border_width` - Border width around each cell in pixels. Defaults to 1.
+- `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
+- `text_color` - Color of score text as a hex string. Defaults to `"#000000"`.
+
+**Color options:**
+
+- `colors` - Color palette for the heatmap. Can be a predefined palette constant (e.g., `HeatmapBuilder::GITHUB_GREEN`), an array of hex color strings (e.g., `%w[#ebedf0 #9be9a8 #40c463]`), or a hash for OKLCH interpolation (e.g., `{ from: "#ebedf0", to: "#216e39", steps: 5 }`). Defaults to `HeatmapBuilder::GITHUB_GREEN`. See [Predefined Color Palettes](#predefined-color-palettes) and [Dynamic Palettes Generation](#dynamic-palettes-generation).
 
 ### Calendar Heatmap Options
 
-All options have defaults and are optional:
+You must provide either `scores:` or `values:` (but not both). All other options are optional keyword arguments with sensible defaults.
 
-```ruby
-HeatmapBuilder.build_calendar(
-  # Data - provide either scores OR values (not both)
-  # Keys can be Date objects or date strings ('2024-01-01')
-  scores: { '2024-01-01' => 2, '2024-01-02' => 4 },  # Pre-calculated scores (0 to num_colors-1)
-  # OR
-  values: { '2024-01-01' => 45.2, '2024-01-02' => 78.5 },  # Arbitrary numeric values
+**Data options:**
 
-  # Value-to-Score Options (only used with values:)
-  value_min: 0,               # Minimum boundary (defaults to actual min)
-  value_max: 100,             # Maximum boundary (defaults to actual max)
-  value_to_score: ->(value:, date:, min:, max:, num_scores:) { ... },  # Custom conversion function
+- `scores` - Hash of pre-calculated scores by date (integers from 0 to number of colors minus 1). Keys can be Date objects or date strings (e.g., `'2024-01-01'`). Required if `values` is not provided.
+- `values` - Hash of arbitrary numeric values by date to be automatically mapped to scores. Keys can be Date objects or date strings. Required if `scores` is not provided. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores).
 
-  # Appearance
-  cell_size: 12,              # Size of each square in pixels
-  cell_spacing: 1,            # Space between squares in pixels
-  font_size: 8,               # Font size for score text
-  border_width: 1,            # Border width around each cell
-  corner_radius: 0,           # Corner radius for rounded cells (0 for square, max: floor(cell_size/2))
-  text_color: "#000000",      # Color of score text
+**Value-to-score conversion options** (only used with `values:`):
 
-  # Colors - can be an array of hex colors or a hash for OKLCH interpolation
-  colors: HeatmapBuilder::GITHUB_GREEN,  # Use predefined palette
-  # OR manually define color array:
-  # colors: %w[#ebedf0 #9be9a8 #40c463 #30a14e #216e39]
-  # OR use OKLCH interpolation:
-  # colors: { from: "#ebedf0", to: "#216e39", steps: 5 }
+- `value_min` - Minimum boundary for value-to-score mapping. Defaults to the minimum value in your data.
+- `value_max` - Maximum boundary for value-to-score mapping. Defaults to the maximum value in your data.
+- `value_to_score` - Custom callable for value-to-score conversion. Receives `value:`, `date:`, `min:`, `max:`, `num_scores:` parameters and must return an integer between 0 and `num_scores - 1`. See [Using Raw Values Instead of Scores](#using-raw-values-instead-of-scores) for details.
 
-  # Calendar-specific options
-  start_of_week: :monday,     # :sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday
-  month_spacing: 5,           # Extra space between months in pixels
-  show_month_labels: true,    # Show month names at top
-  show_day_labels: true,      # Show day abbreviations on left
-  show_outside_cells: false,  # Show inactive cells outside date range
+**Appearance options:**
 
-  # Internationalization
-  day_labels: %w[S M T W T F S],  # Day abbreviations starting from Sunday
-  month_labels: %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec]  # Month abbreviations
-)
-```
+- `cell_size` - Size of each square in pixels. Defaults to 12.
+- `cell_spacing` - Space between squares in pixels. Defaults to 1.
+- `font_size` - Font size for labels in pixels. Defaults to 8.
+- `border_width` - Border width around each cell in pixels. Defaults to 1.
+- `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
+- `text_color` - Color of label text as a hex string. Defaults to `"#000000"`.
+
+**Color options:**
+
+- `colors` - Color palette for the heatmap. Can be a predefined palette constant (e.g., `HeatmapBuilder::GITHUB_GREEN`), an array of hex color strings (e.g., `%w[#ebedf0 #9be9a8 #40c463]`), or a hash for OKLCH interpolation (e.g., `{ from: "#ebedf0", to: "#216e39", steps: 5 }`). Defaults to `HeatmapBuilder::GITHUB_GREEN`. See [Predefined Color Palettes](#predefined-color-palettes) and [Dynamic Palettes Generation](#dynamic-palettes-generation).
+
+**Calendar-specific options:**
+
+- `start_of_week` - First day of the week. One of `:sunday`, `:monday`, `:tuesday`, `:wednesday`, `:thursday`, `:friday`, `:saturday`. Defaults to `:monday`.
+- `month_spacing` - Extra horizontal space between months in pixels. Defaults to 5.
+- `show_month_labels` - Show month names at the top of the calendar. Defaults to `true`.
+- `show_day_labels` - Show day abbreviations on the left side of the calendar. Defaults to `true`.
+- `show_outside_cells` - Show cells outside the date range with inactive styling. Defaults to `false`.
+
+**Internationalization options:**
+
+- `day_labels` - Array of day abbreviations starting from Sunday (7 elements). Defaults to `%w[S M T W T F S]`. See [I18n](#i18n).
+- `month_labels` - Array of month abbreviations from January to December (12 elements). Defaults to `%w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec]`. See [I18n](#i18n).
 
 ### Predefined Color Palettes
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The builder will automatically:
 You can also provide a custom value-to-score conversion function:
 
 ```ruby
-# Custom scoring logic
+# Custom scoring logic - linear distribution
 custom_formula = ->(value:, index:, min:, max:, num_scores:) {
   # Your custom logic here
   # Must return integer between 0 and num_scores-1
@@ -117,6 +117,22 @@ custom_formula = ->(value:, index:, min:, max:, num_scores:) {
 svg = HeatmapBuilder.build_linear(
   values: [10, 20, 30],
   value_to_score: custom_formula
+)
+
+# Logarithmic scale for data with wide range (e.g., 1 to 10000)
+logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {
+  return 0 if value <= 0 || min <= 0
+
+  log_value = Math.log10(value)
+  log_min = Math.log10(min)
+  log_max = Math.log10(max)
+
+  ((log_value - log_min) / (log_max - log_min) * (num_scores - 1)).floor.clamp(0, num_scores - 1)
+}
+
+svg = HeatmapBuilder.build_linear(
+  values: [1, 10, 100, 1000, 10000],
+  value_to_score: logarithmic_formula
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ The callable receives these parameters:
 
 The function must return an integer between 0 and `num_scores - 1`.
 
+**Custom scoring logic - linear distribution example:**
+
 ```ruby
 # Linear distribution (this is the default behavior)
 linear_formula = ->(value:, index:, min:, max:, num_scores:) {
@@ -196,8 +198,11 @@ svg = HeatmapBuilder.build_linear(
   values: [10, 20, 30],
   value_to_score: linear_formula
 )
+```
 
-# Logarithmic scale for data with wide range (e.g., 1 to 10000)
+**Logarithmic scale for data with wide range (e.g., 1 to 10000):**
+
+```ruby
 logarithmic_formula = ->(value:, index:, min:, max:, num_scores:) {
   return 0 if value <= 0 || min <= 0
 

--- a/lib/heatmap-builder.rb
+++ b/lib/heatmap-builder.rb
@@ -17,8 +17,8 @@ module HeatmapBuilder
 
   # Builds a linear (single-row) heatmap visualization.
   #
-  # @param scores [Array<Integer>, nil] Pre-calculated score values (0 to num_colors-1)
-  # @param values [Array<Numeric>, nil] Raw numeric values to be mapped to scores
+  # @param scores [Array<Integer>, nil] Pre-calculated score values (0 to num_colors-1). Required unless values provided.
+  # @param values [Array<Numeric>, nil] Raw numeric values to be mapped to scores. Required unless scores provided.
   # @param options [Hash] Customization options
   # @return [String] SVG markup
   # @see https://github.com/dreikanter/heatmap-builder#linear-heatmaps Full documentation
@@ -31,8 +31,8 @@ module HeatmapBuilder
 
   # Builds a calendar (GitHub-style) heatmap visualization.
   #
-  # @param scores [Hash<Date, Integer>, Hash<String, Integer>, nil] Pre-calculated score values by date
-  # @param values [Hash<Date, Numeric>, Hash<String, Numeric>, nil] Raw numeric values by date
+  # @param scores [Hash<Date, Integer>, Hash<String, Integer>, nil] Pre-calculated score values by date. Required unless values provided.
+  # @param values [Hash<Date, Numeric>, Hash<String, Numeric>, nil] Raw numeric values by date. Required unless scores provided.
   # @param options [Hash] Customization options
   # @return [String] SVG markup
   # @see https://github.com/dreikanter/heatmap-builder#calendar-heatmaps Full documentation

--- a/lib/heatmap-builder.rb
+++ b/lib/heatmap-builder.rb
@@ -9,28 +9,48 @@ require_relative "heatmap_builder/calendar_heatmap_builder"
 module HeatmapBuilder
   class Error < StandardError; end
 
-  # Predefined color palettes for easy access
   GITHUB_GREEN = Builder::GITHUB_GREEN
   BLUE_OCEAN = Builder::BLUE_OCEAN
   WARM_SUNSET = Builder::WARM_SUNSET
   PURPLE_VIBES = Builder::PURPLE_VIBES
   RED_TO_GREEN = Builder::RED_TO_GREEN
 
+  # Builds a linear (single-row) heatmap visualization.
+  #
+  # @param scores [Array<Integer>, nil] Pre-calculated score values (0 to num_colors-1)
+  # @param values [Array<Numeric>, nil] Raw numeric values to be mapped to scores
+  # @param options [Hash] Customization options
+  # @return [String] SVG markup
+  # @see https://github.com/dreikanter/heatmap-builder#linear-heatmaps Full documentation
+  # @example
+  #   HeatmapBuilder.build_linear(scores: [0, 1, 2, 3, 4])
+  #   HeatmapBuilder.build_linear(values: [10, 25, 50, 75, 100], value_min: 0, value_max: 100)
   def self.build_linear(scores: nil, values: nil, **options)
     LinearHeatmapBuilder.new(scores: scores, values: values, **options).build
   end
 
+  # Builds a calendar (GitHub-style) heatmap visualization.
+  #
+  # @param scores [Hash<Date, Integer>, Hash<String, Integer>, nil] Pre-calculated score values by date
+  # @param values [Hash<Date, Numeric>, Hash<String, Numeric>, nil] Raw numeric values by date
+  # @param options [Hash] Customization options
+  # @return [String] SVG markup
+  # @see https://github.com/dreikanter/heatmap-builder#calendar-heatmaps Full documentation
+  # @example
+  #   HeatmapBuilder.build_calendar(scores: { '2024-01-01' => 2, '2024-01-02' => 4 })
+  #   HeatmapBuilder.build_calendar(values: { Date.new(2024, 1, 1) => 45.2 })
   def self.build_calendar(scores: nil, values: nil, **options)
     CalendarHeatmapBuilder.new(scores: scores, values: values, **options).build
   end
 
-  # Backward compatibility methods for v0.1.0 API
+  # @deprecated Use {.build_linear} instead
   def self.generate(scores, options = {})
     warn "[DEPRECATION] `HeatmapBuilder.generate(scores, options)` is deprecated and will be removed in v1.0.0. " \
          "Use `HeatmapBuilder.build_linear(scores: scores, **options)` instead."
     build_linear(scores: scores, **options)
   end
 
+  # @deprecated Use {.build_calendar} instead
   def self.generate_calendar(scores, options = {})
     warn "[DEPRECATION] `HeatmapBuilder.generate_calendar(scores_by_date, options)` is deprecated and will be removed in v1.0.0. " \
          "Use `HeatmapBuilder.build_calendar(scores: scores_by_date, **options)` instead."

--- a/lib/heatmap_builder/value_conversion.rb
+++ b/lib/heatmap_builder/value_conversion.rb
@@ -39,7 +39,7 @@ module HeatmapBuilder
           value: value,
           min: value_min,
           max: value_max,
-          num_scores: color_count,
+          max_score: color_count - 1,
           **params
         )
 

--- a/lib/heatmap_builder/value_conversion.rb
+++ b/lib/heatmap_builder/value_conversion.rb
@@ -57,7 +57,7 @@ module HeatmapBuilder
       else
         range = value_max - value_min
         normalized = (clamped_value - value_min).to_f / range
-        (normalized * (color_count - 1)).floor
+        (normalized * (color_count - 1)).round
       end
     end
   end

--- a/test/calendar_heatmap_builder_test.rb
+++ b/test/calendar_heatmap_builder_test.rb
@@ -140,7 +140,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
 
   it "should accept custom value_to_score callable for calendar" do
     # Custom formula: always return score 2
-    custom_fn = ->(value:, date:, min:, max:, num_scores:) { 2 }
+    custom_fn = ->(value:, date:, min:, max:, max_score:) { 2 }
 
     date_values = {
       Date.new(2024, 1, 1) => 10,
@@ -158,8 +158,8 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
 
   it "should pass date parameter to custom value_to_score" do
     received_params = []
-    custom_fn = ->(value:, date:, min:, max:, num_scores:) {
-      received_params << {value: value, date: date, min: min, max: max, num_scores: num_scores}
+    custom_fn = ->(value:, date:, min:, max:, max_score:) {
+      received_params << {value: value, date: date, min: min, max: max, max_score: max_score}
       0
     }
 

--- a/test/linear_heatmap_builder_test.rb
+++ b/test/linear_heatmap_builder_test.rb
@@ -148,7 +148,7 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
   end
 
   it "should accept custom value_to_score callable" do
-    custom_fn = ->(value:, index:, min:, max:, num_scores:) { 2 }
+    custom_fn = ->(value:, index:, min:, max:, max_score:) { 2 }
 
     builder = HeatmapBuilder::LinearHeatmapBuilder.new(
       values: [10, 20, 30],
@@ -160,7 +160,7 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
   end
 
   it "should validate custom value_to_score returns valid integer" do
-    custom_fn = ->(value:, index:, min:, max:, num_scores:) { 999 }
+    custom_fn = ->(value:, index:, min:, max:, max_score:) { 999 }
 
     builder = HeatmapBuilder::LinearHeatmapBuilder.new(
       values: [10, 20, 30],
@@ -173,7 +173,7 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
   end
 
   it "should validate custom value_to_score returns integer not float" do
-    custom_fn = ->(value:, index:, min:, max:, num_scores:) { 1.5 }
+    custom_fn = ->(value:, index:, min:, max:, max_score:) { 1.5 }
 
     builder = HeatmapBuilder::LinearHeatmapBuilder.new(
       values: [10, 20, 30],
@@ -186,7 +186,7 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
   end
 
   it "should validate custom value_to_score returns non-negative integer" do
-    custom_fn = ->(value:, index:, min:, max:, num_scores:) { -1 }
+    custom_fn = ->(value:, index:, min:, max:, max_score:) { -1 }
 
     builder = HeatmapBuilder::LinearHeatmapBuilder.new(
       values: [10, 20, 30],
@@ -200,8 +200,8 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
 
   it "should pass correct parameters to custom value_to_score" do
     received_params = []
-    custom_fn = ->(value:, index:, min:, max:, num_scores:) {
-      received_params << {value: value, index: index, min: min, max: max, num_scores: num_scores}
+    custom_fn = ->(value:, index:, min:, max:, max_score:) {
+      received_params << {value: value, index: index, min: min, max: max, max_score: max_score}
       0
     }
 
@@ -218,7 +218,7 @@ describe HeatmapBuilder::LinearHeatmapBuilder do
     assert_equal 0, received_params[0][:index]
     assert_equal 0, received_params[0][:min]
     assert_equal 100, received_params[0][:max]
-    assert_equal 5, received_params[0][:num_scores]  # Default GITHUB_GREEN has 5 colors
+    assert_equal 4, received_params[0][:max_score]  # Default GITHUB_GREEN has 5 colors (max_score = 4)
   end
 
   it "should handle empty values array" do


### PR DESCRIPTION
Changes:

- Add YARD comments to the build methods.
- Replace large code examples explaining build options with bullet lists for readability.
- Improve options documentations in the readme.
- Replace `num_scores` with a bit more obvious `max_score`.