### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-01-XX
+
 ### Added
 - Support for raw numeric values with automatic score calculation using linear distribution
 - `values:` parameter as alternative to `scores:` for both linear and calendar heatmaps
@@ -17,12 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rounded corners support for heatmap cells via `corner_radius` option
 - Test coverage reporting with SimpleCov
 - Snapshot testing for comprehensive test coverage
+- YARD documentation for public API methods
+- Logarithmic scale example for custom scoring logic
+- Comprehensive options documentation in README with bullet lists
 
 ### Changed
 - Primary API now uses keyword arguments (`scores:`, `values:`, etc.) for clarity and flexibility
 - Refactored common validation logic into base Builder class
 - Improved test suite with Minitest specs syntax
-- Enhanced README with configuration reference and examples
+- Enhanced README with better organization and forward references
+- Renamed `num_scores` parameter to `max_score` for better clarity in custom scoring functions
+- Changed value-to-score calculation from `floor` to `round` for better score distribution
+- Automatic corner radius clamping to valid range
 
 ### Deprecated
 - `HeatmapBuilder.generate(scores, options)` - use `HeatmapBuilder.build_linear(scores: scores, **options)` instead
@@ -41,5 +49,6 @@ Initial release with core heatmap visualization capabilities.
 - Support for custom start of week (Monday/Sunday)
 - SVG output format for perfect scaling
 
-[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/dreikanter/heatmap-builder/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dreikanter/heatmap-builder/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snapshot testing for visual regression testing
 - YARD documentation for public API methods
 - Logarithmic scale example for custom scoring logic
-- Detailed options documentation in README with bullet lists
+- Detailed options documentation in README
 
 ### Changed
 - Primary API now uses keyword arguments (`scores:`, `values:`, etc.) for clarity and flexibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic color palette generation using OKLCH color space interpolation
 - Rounded corners support for heatmap cells via `corner_radius` option
 - Test coverage reporting with SimpleCov
-- Snapshot testing for comprehensive test coverage
+- Snapshot testing for visual regression testing
 - YARD documentation for public API methods
 - Logarithmic scale example for custom scoring logic
-- Comprehensive options documentation in README with bullet lists
+- Detailed options documentation in README with bullet lists
 
 ### Changed
 - Primary API now uses keyword arguments (`scores:`, `values:`, etc.) for clarity and flexibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2025-01-XX
+## [0.2.0] - 2025-10-02
 
 ### Added
 - Support for raw numeric values with automatic score calculation using linear distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved test suite with Minitest specs syntax
 - Enhanced README with better organization and forward references
 - Renamed `num_scores` parameter to `max_score` for better clarity in custom scoring functions
-- Changed value-to-score calculation from `floor` to `round` for better score distribution
 - Automatic corner radius clamping to valid range
 
 ### Deprecated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heatmap-builder (0.1.0)
+    heatmap-builder (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # HeatmapBuilder
 
-> ⚠️ This library is currently in active development. While functional, you may encounter bugs and breaking changes. Use with caution in production environments.
-
 A Ruby gem that generates embeddable SVG heatmap visualizations with GitHub-style calendar layouts and linear progress indicators. Perfect for Rails applications and any project that needs to display activity data in a visual format.
 
 ![GitHub-style Calendar](examples/calendar_github_style.svg)

--- a/lib/heatmap_builder/version.rb
+++ b/lib/heatmap_builder/version.rb
@@ -1,3 +1,3 @@
 module HeatmapBuilder
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Changes:

- Remove readme warning.
- Update changelog.
- Bump the version number to 0.2.0.