### PR TITLE
Rename CalendarHeatmapBuilder to Calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Renamed `CalendarHeatmapBuilder` to `Calendar` — the full name `HeatmapBuilder::CalendarHeatmapBuilder` was redundant; `HeatmapBuilder::Calendar` is cleaner
+- `CalendarHeatmapBuilder` is kept as a backward-compatible alias
+
 ### Fixed
 - Month labels and SVG width now render correctly when data starts or ends mid-month
 - `month_spacing` no longer produces spurious gaps at the edges of the calendar grid

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 
 **Color options:**
 
-- `colors` - Color palette for the heatmap. Can be a predefined palette constant (e.g., `HeatmapBuilder::CalendarHeatmapBuilder::GITHUB_GREEN`), an array of hex color strings (e.g., `%w[#ebedf0 #9be9a8 #40c463]`), or a hash for OKLCH interpolation (e.g., `{ from: "#ebedf0", to: "#216e39", steps: 5 }`). Defaults to `HeatmapBuilder::CalendarHeatmapBuilder::GITHUB_GREEN`. See [Predefined Color Palettes](#predefined-color-palettes) and [Dynamic Palettes Generation](#dynamic-palettes-generation).
+- `colors` - Color palette for the heatmap. Can be a predefined palette constant (e.g., `HeatmapBuilder::Calendar::GITHUB_GREEN`), an array of hex color strings (e.g., `%w[#ebedf0 #9be9a8 #40c463]`), or a hash for OKLCH interpolation (e.g., `{ from: "#ebedf0", to: "#216e39", steps: 5 }`). Defaults to `HeatmapBuilder::Calendar::GITHUB_GREEN`. See [Predefined Color Palettes](#predefined-color-palettes) and [Dynamic Palettes Generation](#dynamic-palettes-generation).
 
 **Calendar-specific options:**
 
@@ -155,7 +155,7 @@ svg = HeatmapBuilder.build_calendar(
 #### GitHub Green (Default)
 
 ```ruby
-HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::CalendarHeatmapBuilder::GITHUB_GREEN)
+HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Calendar::GITHUB_GREEN)
 ```
 
 ![Default Calendar](examples/calendar_default.svg)
@@ -163,7 +163,7 @@ HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Cal
 #### Blue Ocean
 
 ```ruby
-HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::CalendarHeatmapBuilder::BLUE_OCEAN)
+HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Calendar::BLUE_OCEAN)
 ```
 
 ![Blue Ocean Calendar](examples/calendar_blue_ocean.svg)
@@ -171,7 +171,7 @@ HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Cal
 #### Warm Sunset
 
 ```ruby
-HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::CalendarHeatmapBuilder::WARM_SUNSET)
+HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Calendar::WARM_SUNSET)
 ```
 
 ![Warm Sunset Calendar](examples/calendar_warm_sunset.svg)
@@ -179,7 +179,7 @@ HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Cal
 #### Purple Vibes
 
 ```ruby
-HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::CalendarHeatmapBuilder::PURPLE_VIBES)
+HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Calendar::PURPLE_VIBES)
 ```
 
 ![Purple Vibes Calendar](examples/calendar_purple_vibes.svg)
@@ -187,7 +187,7 @@ HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Cal
 #### Red to Green
 
 ```ruby
-HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::CalendarHeatmapBuilder::RED_TO_GREEN)
+HeatmapBuilder.build_calendar(scores: calendar_data, colors: HeatmapBuilder::Calendar::RED_TO_GREEN)
 ```
 
 ![Red to Green Calendar](examples/calendar_red_to_green.svg)

--- a/bin/generate_examples
+++ b/bin/generate_examples
@@ -51,7 +51,7 @@ def generate_sample_svgs(force: false)
   generate_example("calendar_blue_ocean.svg", "calendar with Blue Ocean palette", force: force) do
     HeatmapBuilder.build_calendar(
       scores: calendar_data,
-      colors: HeatmapBuilder::CalendarHeatmapBuilder::BLUE_OCEAN,
+      colors: HeatmapBuilder::Calendar::BLUE_OCEAN,
       cell_size: 14,
       month_spacing: 0
     )
@@ -60,7 +60,7 @@ def generate_sample_svgs(force: false)
   generate_example("calendar_warm_sunset.svg", "calendar with Warm Sunset palette", force: force) do
     HeatmapBuilder.build_calendar(
       scores: calendar_data,
-      colors: HeatmapBuilder::CalendarHeatmapBuilder::WARM_SUNSET,
+      colors: HeatmapBuilder::Calendar::WARM_SUNSET,
       cell_size: 14,
       month_spacing: 0
     )
@@ -69,7 +69,7 @@ def generate_sample_svgs(force: false)
   generate_example("calendar_purple_vibes.svg", "calendar with Purple Vibes palette", force: force) do
     HeatmapBuilder.build_calendar(
       scores: calendar_data,
-      colors: HeatmapBuilder::CalendarHeatmapBuilder::PURPLE_VIBES,
+      colors: HeatmapBuilder::Calendar::PURPLE_VIBES,
       cell_size: 14,
       month_spacing: 0
     )
@@ -78,7 +78,7 @@ def generate_sample_svgs(force: false)
   generate_example("calendar_red_to_green.svg", "calendar with Red to Green palette", force: force) do
     HeatmapBuilder.build_calendar(
       scores: calendar_data,
-      colors: HeatmapBuilder::CalendarHeatmapBuilder::RED_TO_GREEN,
+      colors: HeatmapBuilder::Calendar::RED_TO_GREEN,
       cell_size: 14,
       month_spacing: 0
     )

--- a/lib/heatmap-builder.rb
+++ b/lib/heatmap-builder.rb
@@ -2,7 +2,7 @@ require_relative "heatmap_builder/version"
 require_relative "heatmap_builder/svg_helpers"
 require_relative "heatmap_builder/color_helpers"
 require_relative "heatmap_builder/value_conversion"
-require_relative "heatmap_builder/calendar_heatmap_builder"
+require_relative "heatmap_builder/calendar"
 
 module HeatmapBuilder
   class Error < StandardError; end
@@ -18,7 +18,7 @@ module HeatmapBuilder
   #   HeatmapBuilder.build_calendar(scores: { '2024-01-01' => 2, '2024-01-02' => 4 })
   #   HeatmapBuilder.build_calendar(values: { Date.new(2024, 1, 1) => 45.2 })
   def self.build_calendar(scores: nil, values: nil, **options)
-    CalendarHeatmapBuilder.new(scores: scores, values: values, **options).build
+    Calendar.new(scores: scores, values: values, **options).build
   end
 
   # @deprecated Use {.build_calendar} instead
@@ -27,4 +27,7 @@ module HeatmapBuilder
          "Use `HeatmapBuilder.build_calendar(scores: scores_by_date, **options)` instead."
     build_calendar(scores: scores, **options)
   end
+
+  # @deprecated Use {Calendar} instead
+  CalendarHeatmapBuilder = Calendar
 end

--- a/lib/heatmap_builder/calendar.rb
+++ b/lib/heatmap_builder/calendar.rb
@@ -4,7 +4,7 @@ require_relative "color_helpers"
 require_relative "value_conversion"
 
 module HeatmapBuilder
-  class CalendarHeatmapBuilder
+  class Calendar
     include SvgHelpers
     include ValueConversion
 

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-describe HeatmapBuilder::CalendarHeatmapBuilder do
+describe HeatmapBuilder::Calendar do
   def scores
     {
       "2024-01-01" => 1,
@@ -11,7 +11,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
   end
 
   def builder
-    HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores)
+    HeatmapBuilder::Calendar.new(scores: scores)
   end
 
   it "should build SVG with default options" do
@@ -20,46 +20,46 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
   end
 
   it "should use Monday as start of week when specified" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, start_of_week: :monday)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, start_of_week: :monday)
     assert_matches_snapshot(builder.build, "start_with_monday.svg")
   end
 
   it "should use Sunday as start of week when specified" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, start_of_week: :sunday)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, start_of_week: :sunday)
     assert_matches_snapshot(builder.build, "start_with_sunday.svg")
   end
 
   it "should display month labels when enabled" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, show_month_labels: true)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, show_month_labels: true)
     assert_matches_snapshot(builder.build, "with_months.svg")
   end
 
   it "should display day labels when enabled" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, show_day_labels: true)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, show_day_labels: true)
     assert_matches_snapshot(builder.build, "with_dows.svg")
   end
 
   it "should use custom colors when provided" do
     colors = %w[#ffffff #ff0000 #00ff00]
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, colors: colors)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, colors: colors)
     assert_matches_snapshot(builder.build, "custom_colors.svg")
   end
 
   it "should raise errors for invalid inputs" do
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::CalendarHeatmapBuilder.new(scores: "invalid")
+      HeatmapBuilder::Calendar.new(scores: "invalid")
     end
 
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, cell_size: 0)
+      HeatmapBuilder::Calendar.new(scores: scores, cell_size: 0)
     end
 
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, colors: [])
+      HeatmapBuilder::Calendar.new(scores: scores, colors: [])
     end
 
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, start_of_week: :invalid)
+      HeatmapBuilder::Calendar.new(scores: scores, start_of_week: :invalid)
     end
   end
 
@@ -69,23 +69,23 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 2) => 2
     }
 
-    assert HeatmapBuilder::CalendarHeatmapBuilder.new(scores: date_scores)
+    assert HeatmapBuilder::Calendar.new(scores: date_scores)
   end
 
   it "should handle empty scores hash" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {})
+    builder = HeatmapBuilder::Calendar.new(scores: {})
     assert builder.build
   end
 
   it "should apply corner_radius to cells" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, corner_radius: 2)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, corner_radius: 2)
     svg = builder.build
 
     assert_includes svg, 'rx="2"'
   end
 
   it "should normalize corner_radius to maximum allowed value" do
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(scores: scores, cell_size: 12, corner_radius: 100)
+    builder = HeatmapBuilder::Calendar.new(scores: scores, cell_size: 12, corner_radius: 100)
     svg = builder.build
 
     assert_includes svg, 'rx="6"'
@@ -99,7 +99,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 3) => 100
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       values: date_values,
       value_min: 0,
       value_max: 100
@@ -115,7 +115,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 3) => 100
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       values: date_values,
       value_min: 0,
       value_max: 100
@@ -132,7 +132,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 3) => 30
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(values: date_values)
+    builder = HeatmapBuilder::Calendar.new(values: date_values)
     svg = builder.build
 
     assert_matches_snapshot(svg, "calendar_values_auto_boundaries.svg")
@@ -147,7 +147,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 2) => 20
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       values: date_values,
       value_to_score: custom_fn
     )
@@ -170,7 +170,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       date2 => 20
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       values: date_values,
       value_min: 0,
       value_max: 100,
@@ -191,7 +191,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       "2024-01-02" => 20
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(values: date_values)
+    builder = HeatmapBuilder::Calendar.new(values: date_values)
     svg = builder.build
 
     assert_matches_snapshot(svg, "calendar_values_string_dates.svg")
@@ -203,7 +203,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
     month_scores = {}
     (Date.new(2024, 1, 25)..Date.new(2024, 2, 5)).each { |d| month_scores[d] = 1 }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       scores: month_scores,
       month_spacing: 5,
       start_of_week: :monday
@@ -215,7 +215,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
     month_scores = {}
     (Date.new(2024, 1, 25)..Date.new(2024, 2, 5)).each { |d| month_scores[d] = 1 }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       scores: month_scores,
       month_spacing: 5,
       start_of_week: :monday,
@@ -228,7 +228,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
     month_scores = {}
     (Date.new(2024, 1, 25)..Date.new(2024, 2, 5)).each { |d| month_scores[d] = 1 }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       scores: month_scores,
       month_spacing: 0,
       start_of_week: :monday
@@ -242,7 +242,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
     month_scores = {}
     (Date.new(2024, 11, 1)..Date.new(2025, 1, 31)).each { |d| month_scores[d] = 1 }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(
+    builder = HeatmapBuilder::Calendar.new(
       scores: month_scores,
       month_spacing: 10,
       start_of_week: :monday
@@ -252,7 +252,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
 
   it "should raise error if both scores and values provided for calendar" do
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::CalendarHeatmapBuilder.new(
+      HeatmapBuilder::Calendar.new(
         scores: {Date.new(2024, 1, 1) => 1},
         values: {Date.new(2024, 1, 1) => 10}
       )
@@ -265,7 +265,7 @@ describe HeatmapBuilder::CalendarHeatmapBuilder do
       Date.new(2024, 1, 1) => 0
     }
 
-    builder = HeatmapBuilder::CalendarHeatmapBuilder.new(values: date_values)
+    builder = HeatmapBuilder::Calendar.new(values: date_values)
     svg = builder.build
 
     assert_matches_snapshot(svg, "calendar_values_empty.svg")

--- a/test/heatmap_builder_test.rb
+++ b/test/heatmap_builder_test.rb
@@ -5,7 +5,7 @@ describe HeatmapBuilder do
     refute_nil ::HeatmapBuilder::VERSION
   end
 
-  it ".build_calendar should delegate to CalendarHeatmapBuilder" do
+  it ".build_calendar should delegate to Calendar" do
     scores_by_date = {"2024-01-01" => 1}
     svg = HeatmapBuilder.build_calendar(scores: scores_by_date)
 
@@ -28,53 +28,53 @@ describe HeatmapBuilder do
   describe "common validations" do
     it "should raise error for non-positive cell_size" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, cell_size: 0)
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, cell_size: 0)
       end
 
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, cell_size: -5)
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, cell_size: -5)
       end
     end
 
     it "should raise error for non-positive font_size" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, font_size: 0)
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, font_size: 0)
       end
 
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, font_size: -3)
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, font_size: -3)
       end
     end
 
     it "should raise error for colors array with less than 2 colors" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: ["#ffffff"])
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: ["#ffffff"])
       end
     end
 
     it "should raise error for colors hash missing required keys" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000"})
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000"})
       end
 
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", steps: 3})
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", steps: 3})
       end
 
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: {to: "#000000", steps: 3})
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: {to: "#000000", steps: 3})
       end
     end
 
     it "should raise error for steps not being an Integer" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000", steps: "3"})
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000", steps: "3"})
       end
     end
 
     it "should raise error for steps less than 2" do
       assert_raises(HeatmapBuilder::Error) do
-        HeatmapBuilder::CalendarHeatmapBuilder.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000", steps: 1})
+        HeatmapBuilder::Calendar.new(scores: {"2024-01-01" => 1}, colors: {from: "#ffffff", to: "#000000", steps: 1})
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR renames the `CalendarHeatmapBuilder` class to `Calendar` for a simpler, more concise API while maintaining backward compatibility through a deprecation alias.

## Key Changes
- Renamed `CalendarHeatmapBuilder` class to `Calendar` in `lib/heatmap_builder/calendar.rb` (file also renamed from `calendar_heatmap_builder.rb`)
- Updated all test files to use the new `HeatmapBuilder::Calendar` class name
- Updated README.md documentation to reference `HeatmapBuilder::Calendar` instead of `HeatmapBuilder::CalendarHeatmapBuilder`
- Updated example generation script to use the new class name
- Added a deprecation alias `CalendarHeatmapBuilder = Calendar` in the main module for backward compatibility
- Updated the main entry point `lib/heatmap-builder.rb` to require the renamed file and use the new class name

## Implementation Details
- The deprecation alias allows existing code using `HeatmapBuilder::CalendarHeatmapBuilder` to continue working without breaking changes
- All predefined color palette constants (e.g., `GITHUB_GREEN`, `BLUE_OCEAN`) are now accessed via `HeatmapBuilder::Calendar::` instead of `HeatmapBuilder::CalendarHeatmapBuilder::`
- The public API method `HeatmapBuilder.build_calendar` continues to work as before, now delegating to the renamed `Calendar` class

https://claude.ai/code/session_01EdDKNkrFVPNkn7iFguZQ1t