### PR TITLE
Relax version constraints for rake and minitest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-11
+
+### Changed
+- Relaxed `rake` and `minitest` development dependency constraints from `~>` to `>=` to allow future major versions
+
 ## [0.3.0] - 2026-06-11
 
 ### Changed
@@ -54,7 +59,8 @@ Initial release with core heatmap visualization capabilities.
 - Support for custom start of week (Monday/Sunday)
 - SVG output format for perfect scaling
 
-[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/dreikanter/heatmap-builder/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/dreikanter/heatmap-builder/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dreikanter/heatmap-builder/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dreikanter/heatmap-builder/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,20 @@
 PATH
   remote: .
   specs:
-    heatmap-builder (0.3.0)
+    heatmap-builder (0.3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
     docile (1.4.1)
+    drb (2.2.3)
     json (2.19.9)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -69,10 +72,10 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 2.0)
   heatmap-builder!
-  minitest (~> 5.0)
-  rake (~> 13.0)
+  minitest (>= 5.0)
+  rake (>= 13.0)
   simplecov (~> 0.22)
   standard (~> 1.0)
 
 BUNDLED WITH
-  4.0.14
+  4.0.9

--- a/heatmap-builder.gemspec
+++ b/heatmap-builder.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3"
 
   spec.add_development_dependency "bundler", ">= 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", ">= 13.0"
+  spec.add_development_dependency "minitest", ">= 5.0"
   spec.add_development_dependency "standard", "~> 1.0"
   spec.add_development_dependency "simplecov", "~> 0.22"
 end

--- a/lib/heatmap_builder/version.rb
+++ b/lib/heatmap_builder/version.rb
@@ -1,3 +1,3 @@
 module HeatmapBuilder
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## Summary
Updated the version constraints for `rake` and `minitest` development dependencies to be more permissive, allowing for greater flexibility in dependency resolution.

## Changes
- Changed `rake` dependency from `~> 13.0` to `>= 13.0`
- Changed `minitest` dependency from `~> 5.0` to `>= 5.0`

## Details
These changes relax the version constraints from pessimistic version operators (`~>`) to minimum version operators (`>=`). This allows:
- Easier integration with projects that may have newer versions of these tools
- Better compatibility with other gems that depend on newer versions of rake or minitest
- More flexibility in the dependency resolution process while still maintaining a minimum supported version

The other development dependencies (`standard` and `simplecov`) retain their original pessimistic version constraints.
