### PR TITLE
Add border color factor option to control cell border colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `border_color_factor` option controls how the cell border color is derived
+  from each cell's color by scaling its OKLCH lightness. Setting it to `1` makes
+  the border match the cell color, in which case the (now invisible) border is
+  omitted from the SVG entirely. Defaults to `0.9`, preserving previous output.
+
 ## [0.4.1] - 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-06-15
 
 ### Added
-- New `border_color_factor` option controls how the cell border color is derived
+- New `border_lightness_factor` option controls how the cell border color is derived
   from each cell's color by scaling its OKLCH lightness. Setting it to `1` makes
   the border match the cell color, in which case the (now invisible) border is
   omitted from the SVG entirely. Defaults to `0.9`, preserving previous output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-15
+
 ### Added
 - New `border_color_factor` option controls how the cell border color is derived
   from each cell's color by scaling its OKLCH lightness. Setting it to `1` makes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heatmap-builder (0.4.1)
+    heatmap-builder (0.4.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ svg = HeatmapBuilder.build_calendar(scores: calendar_data, colors: neon_gradient
 
 The OKLCH color space ensures perceptually uniform color transitions, making gradients appear smooth and natural to the human eye.
 
+### Cell Borders
+
+Each cell has a border whose color is derived from the cell's own color. The `border_width` option sets its thickness, and `border_color_factor` controls its shade: the cell color's OKLCH lightness is multiplied by this factor, so values below `1` produce a darker border (the default `0.9` is a subtle darkening).
+
+Setting `border_color_factor` to `1` keeps the border color identical to the cell color. In that case the border is invisible, so it is omitted from the SVG entirely.
+
+```ruby
+HeatmapBuilder.build_calendar(
+  scores: calendar_data,
+  border_width: 1,
+  border_color_factor: 0.7
+)
+```
+
 ### Rounded Corners
 
 Calendar heatmaps support rounded corners using the `corner_radius` option.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 - `cell_spacing` - Space between squares in pixels. Defaults to 1.
 - `font_size` - Font size for labels in pixels. Defaults to 8.
 - `border_width` - Border width around each cell in pixels. Defaults to 1.
+- `border_color_factor` - Controls the border color, derived from each cell's color by scaling its lightness (in OKLCH) by this factor. Values below 1 produce a darker border; a value of 1 makes the border match the cell color, in which case the border is omitted entirely. Must be positive. Defaults to 0.9.
 - `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
 
 **Color options:**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You must provide either `scores:` or `values:` (but not both). All other options
 - `cell_spacing` - Space between squares in pixels. Defaults to 1.
 - `font_size` - Font size for labels in pixels. Defaults to 8.
 - `border_width` - Border width around each cell in pixels. Defaults to 1.
-- `border_color_factor` - Controls the border color, derived from each cell's color by scaling its lightness (in OKLCH) by this factor. Values below 1 produce a darker border; a value of 1 makes the border match the cell color, in which case the border is omitted entirely. Must be positive. Defaults to 0.9.
+- `border_lightness_factor` - Controls the border color, derived from each cell's color by scaling its lightness (in OKLCH) by this factor. Values below 1 produce a darker border; a value of 1 makes the border match the cell color, in which case the border is omitted entirely. Must be positive. Defaults to 0.9.
 - `corner_radius` - Corner radius for rounded cells. Must be between 0 (square corners) and `floor(cell_size/2)` (circular cells). Values outside this range are automatically clamped. Defaults to 0.
 
 **Color options:**
@@ -218,15 +218,15 @@ The OKLCH color space ensures perceptually uniform color transitions, making gra
 
 ### Cell Borders
 
-Each cell has a border whose color is derived from the cell's own color. The `border_width` option sets its thickness, and `border_color_factor` controls its shade: the cell color's OKLCH lightness is multiplied by this factor, so values below `1` produce a darker border (the default `0.9` is a subtle darkening).
+Each cell has a border whose color is derived from the cell's own color. The `border_width` option sets its thickness, and `border_lightness_factor` controls its shade: the cell color's OKLCH lightness is multiplied by this factor, so values below `1` produce a darker border (the default `0.9` is a subtle darkening).
 
-Setting `border_color_factor` to `1` keeps the border color identical to the cell color. In that case the border is invisible, so it is omitted from the SVG entirely.
+Setting `border_lightness_factor` to `1` keeps the border color identical to the cell color. In that case the border is invisible, so it is omitted from the SVG entirely.
 
 ```ruby
 HeatmapBuilder.build_calendar(
   scores: calendar_data,
   border_width: 1,
-  border_color_factor: 0.7
+  border_lightness_factor: 0.7
 )
 ```
 

--- a/lib/heatmap_builder/calendar.rb
+++ b/lib/heatmap_builder/calendar.rb
@@ -19,6 +19,7 @@ module HeatmapBuilder
       cell_spacing: 1,
       font_size: 8,
       border_width: 1,
+      border_color_factor: 0.9,
       corner_radius: 0,
       colors: GITHUB_GREEN,
       start_of_week: :monday,
@@ -90,6 +91,7 @@ module HeatmapBuilder
     def validate_options!
       raise Error, "cell_size must be positive" unless options[:cell_size].positive?
       raise Error, "font_size must be positive" unless options[:font_size].positive?
+      raise Error, "border_color_factor must be positive" unless options[:border_color_factor].positive?
       validate_colors_option!
       validate_scores_or_values!
       validate_value_boundaries! if values
@@ -297,6 +299,7 @@ module HeatmapBuilder
         x, y, color,
         cell_size: options[:cell_size],
         border_width: options[:border_width],
+        border_color_factor: options[:border_color_factor],
         corner_radius: options[:corner_radius]
       )
 

--- a/lib/heatmap_builder/calendar.rb
+++ b/lib/heatmap_builder/calendar.rb
@@ -19,7 +19,7 @@ module HeatmapBuilder
       cell_spacing: 1,
       font_size: 8,
       border_width: 1,
-      border_color_factor: 0.9,
+      border_lightness_factor: 0.9,
       corner_radius: 0,
       colors: GITHUB_GREEN,
       start_of_week: :monday,
@@ -91,7 +91,7 @@ module HeatmapBuilder
     def validate_options!
       raise Error, "cell_size must be positive" unless options[:cell_size].positive?
       raise Error, "font_size must be positive" unless options[:font_size].positive?
-      raise Error, "border_color_factor must be positive" unless options[:border_color_factor].positive?
+      raise Error, "border_lightness_factor must be positive" unless options[:border_lightness_factor].positive?
       validate_colors_option!
       validate_scores_or_values!
       validate_value_boundaries! if values
@@ -299,7 +299,7 @@ module HeatmapBuilder
         x, y, color,
         cell_size: options[:cell_size],
         border_width: options[:border_width],
-        border_color_factor: options[:border_color_factor],
+        border_lightness_factor: options[:border_lightness_factor],
         corner_radius: options[:corner_radius]
       )
 

--- a/lib/heatmap_builder/color_helpers.rb
+++ b/lib/heatmap_builder/color_helpers.rb
@@ -9,7 +9,7 @@ module HeatmapBuilder
         colors[color_index]
       end
 
-      def darker_color(hex_color, factor: 0.9)
+      def adjust_lightness(hex_color, factor: 0.9)
         rgb = hex_to_rgb(hex_color)
         oklch = rgb_to_oklch(*rgb)
 

--- a/lib/heatmap_builder/color_helpers.rb
+++ b/lib/heatmap_builder/color_helpers.rb
@@ -9,7 +9,7 @@ module HeatmapBuilder
         colors[color_index]
       end
 
-      def adjust_lightness(hex_color, factor: 0.9)
+      def adjust_lightness(hex_color, factor:)
         rgb = hex_to_rgb(hex_color)
         oklch = rgb_to_oklch(*rgb)
 

--- a/lib/heatmap_builder/svg_helpers.rb
+++ b/lib/heatmap_builder/svg_helpers.rb
@@ -54,17 +54,17 @@ module HeatmapBuilder
       str.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
     end
 
-    def cell_border(x, y, color, cell_size:, border_width:, corner_radius:, border_color_factor: 0.9)
+    def cell_border(x, y, color, cell_size:, border_width:, corner_radius:, border_lightness_factor: 0.9)
       return "" unless border_width > 0
       # A factor of 1 leaves the color unchanged, so the border matches the
       # fill exactly and would be invisible. Skip drawing it entirely.
-      return "" if border_color_factor == 1
+      return "" if border_lightness_factor == 1
 
       inset = border_width / 2.0
       border_x = x + inset
       border_y = y + inset
       border_size = cell_size - border_width
-      border_color = ColorHelpers.darker_color(color, factor: border_color_factor)
+      border_color = ColorHelpers.adjust_lightness(color, factor: border_lightness_factor)
       border_radius = (corner_radius > 0) ? [corner_radius - inset, 0].max : 0
 
       svg_rect(

--- a/lib/heatmap_builder/svg_helpers.rb
+++ b/lib/heatmap_builder/svg_helpers.rb
@@ -54,14 +54,17 @@ module HeatmapBuilder
       str.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
     end
 
-    def cell_border(x, y, color, cell_size:, border_width:, corner_radius:)
+    def cell_border(x, y, color, cell_size:, border_width:, corner_radius:, border_color_factor: 0.9)
       return "" unless border_width > 0
+      # A factor of 1 leaves the color unchanged, so the border matches the
+      # fill exactly and would be invisible. Skip drawing it entirely.
+      return "" if border_color_factor == 1
 
       inset = border_width / 2.0
       border_x = x + inset
       border_y = y + inset
       border_size = cell_size - border_width
-      border_color = ColorHelpers.darker_color(color)
+      border_color = ColorHelpers.darker_color(color, factor: border_color_factor)
       border_radius = (corner_radius > 0) ? [corner_radius - inset, 0].max : 0
 
       svg_rect(

--- a/lib/heatmap_builder/version.rb
+++ b/lib/heatmap_builder/version.rb
@@ -1,3 +1,3 @@
 module HeatmapBuilder
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -61,6 +61,23 @@ describe HeatmapBuilder::Calendar do
     assert_raises(HeatmapBuilder::Error) do
       HeatmapBuilder::Calendar.new(scores: scores, start_of_week: :invalid)
     end
+
+    assert_raises(HeatmapBuilder::Error) do
+      HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0)
+    end
+  end
+
+  it "should use border_color_factor to derive the border color" do
+    light = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0.9).build
+    dark = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0.5).build
+
+    refute_equal light, dark
+  end
+
+  it "should omit the border when border_color_factor is 1" do
+    svg = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 1).build
+
+    refute_includes svg, "stroke="
   end
 
   it "should accept Date objects as keys" do

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -63,19 +63,19 @@ describe HeatmapBuilder::Calendar do
     end
 
     assert_raises(HeatmapBuilder::Error) do
-      HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0)
+      HeatmapBuilder::Calendar.new(scores: scores, border_lightness_factor: 0)
     end
   end
 
-  it "should use border_color_factor to derive the border color" do
-    light = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0.9).build
-    dark = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 0.5).build
+  it "should use border_lightness_factor to derive the border color" do
+    light = HeatmapBuilder::Calendar.new(scores: scores, border_lightness_factor: 0.9).build
+    dark = HeatmapBuilder::Calendar.new(scores: scores, border_lightness_factor: 0.5).build
 
     refute_equal light, dark
   end
 
-  it "should omit the border when border_color_factor is 1" do
-    svg = HeatmapBuilder::Calendar.new(scores: scores, border_color_factor: 1).build
+  it "should omit the border when border_lightness_factor is 1" do
+    svg = HeatmapBuilder::Calendar.new(scores: scores, border_lightness_factor: 1).build
 
     refute_includes svg, "stroke="
   end

--- a/test/color_helpers_test.rb
+++ b/test/color_helpers_test.rb
@@ -7,7 +7,7 @@ describe HeatmapBuilder::ColorHelpers do
 
   it ".adjust_lightness should maintain hue while reducing lightness" do
     original = "#ff0000"
-    darker = HeatmapBuilder::ColorHelpers.adjust_lightness(original)
+    darker = HeatmapBuilder::ColorHelpers.adjust_lightness(original, factor: 0.9)
 
     refute_equal original, darker
     assert_match(valid_hex_color, darker)

--- a/test/color_helpers_test.rb
+++ b/test/color_helpers_test.rb
@@ -5,9 +5,9 @@ describe HeatmapBuilder::ColorHelpers do
     /^#[0-9a-f]{6}$/
   end
 
-  it ".darker_color should maintain hue while reducing lightness" do
+  it ".adjust_lightness should maintain hue while reducing lightness" do
     original = "#ff0000"
-    darker = HeatmapBuilder::ColorHelpers.darker_color(original)
+    darker = HeatmapBuilder::ColorHelpers.adjust_lightness(original)
 
     refute_equal original, darker
     assert_match(valid_hex_color, darker)


### PR DESCRIPTION
## Summary
This PR introduces a new `border_color_factor` option that allows users to control how cell border colors are derived from their cell colors. When set to 1, the border becomes invisible and is omitted from the SVG entirely.

## Key Changes
- Added `border_color_factor` option (defaults to 0.9) that scales the OKLCH lightness of a cell's color to determine its border color
- Values below 1 produce darker borders; a value of 1 makes the border match the cell color exactly
- When `border_color_factor` is 1, the border is omitted from the SVG output since it would be invisible
- Added validation to ensure `border_color_factor` is positive
- Updated `ColorHelpers.darker_color()` to accept a `factor` parameter instead of using a hardcoded value
- Updated documentation with examples and explanation of the new option
- Added comprehensive test coverage for the new functionality

## Implementation Details
- The `border_color_factor` parameter is passed through the rendering pipeline from `Calendar` to `svg_helpers.cell_border()`
- Border color derivation now uses OKLCH color space scaling, ensuring perceptually uniform results
- The optimization to skip border rendering when `border_color_factor == 1` reduces SVG output size for cases where borders would be invisible
- Maintains backward compatibility by defaulting to 0.9, which preserves the previous visual output
