### PR TITLE
Fix frozen-string-literal warnings via map/join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-29
+
+### Fixed
+- Silenced "literal string will be frozen in the future" warnings emitted when
+  building SVG output. The hand-rolled mutable string buffers in `Calendar` were
+  replaced with `map`/`flat_map`/`filter_map` + `join` (matching how `build`
+  already assembles SVG fragments), and every file under `lib/` carries the
+  `# frozen_string_literal: true` magic comment. This makes the gem forward
+  compatible with Ruby's upcoming frozen-string-literal default.
+
 ## [0.4.3] - 2026-06-15
 
 ### Fixed
@@ -109,7 +119,8 @@ Initial release with core heatmap visualization capabilities.
 - Support for custom start of week (Monday/Sunday)
 - SVG output format for perfect scaling
 
-[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/dreikanter/heatmap-builder/compare/v0.4.0...v0.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heatmap-builder (0.4.3)
+    heatmap-builder (0.4.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/heatmap-builder.rb
+++ b/lib/heatmap-builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "heatmap_builder/version"
 require_relative "heatmap_builder/svg_helpers"
 require_relative "heatmap_builder/color_helpers"

--- a/lib/heatmap_builder/calendar.rb
+++ b/lib/heatmap_builder/calendar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "date"
 require_relative "svg_helpers"
 require_relative "color_helpers"
@@ -263,13 +265,11 @@ module HeatmapBuilder
     end
 
     def calendar_cells_svg
-      svg = ""
-      column_layout.each do |col|
-        col[:days].each do |date, day_index|
-          svg << render_cell(date, col[:index], day_index, col[:x_offset])
+      column_layout.flat_map do |col|
+        col[:days].map do |date, day_index|
+          render_cell(date, col[:index], day_index, col[:x_offset])
         end
-      end
-      svg
+      end.join
     end
 
     def render_cell(current_date, column_index, day_index, x_offset)
@@ -329,31 +329,22 @@ module HeatmapBuilder
     def day_labels_svg
       return "" unless options[:show_day_labels]
 
-      day_names = day_names_for_week_start
-      svg = ""
-
-      day_names.each_with_index do |day_name, index|
+      day_names_for_week_start.map.with_index do |day_name, index|
         y = month_label_offset + index * (options[:cell_size] + options[:cell_spacing]) + options[:cell_size] / 2 + options[:font_size] * FONT_VERTICAL_CENTER_RATIO
-        svg << svg_text(
+        svg_text(
           day_name,
           x: options[:font_size], y: y,
           font_size: options[:font_size], fill: LABEL_COLOR
         )
-      end
-
-      svg
+      end.join
     end
 
     def month_labels_svg
       return "" unless options[:show_month_labels]
 
-      svg = ""
-      column_layout.each do |col|
-        if col[:first_of_month]
-          svg << month_label_at(col[:index], col[:x_offset], col[:month_date])
-        end
-      end
-      svg
+      column_layout.filter_map do |col|
+        month_label_at(col[:index], col[:x_offset], col[:month_date]) if col[:first_of_month]
+      end.join
     end
 
     # A week carries its month's label only when every one of its seven days

--- a/lib/heatmap_builder/color_helpers.rb
+++ b/lib/heatmap_builder/color_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HeatmapBuilder
   module ColorHelpers
     class << self

--- a/lib/heatmap_builder/svg_helpers.rb
+++ b/lib/heatmap_builder/svg_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HeatmapBuilder
   module SvgHelpers
     private

--- a/lib/heatmap_builder/value_conversion.rb
+++ b/lib/heatmap_builder/value_conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HeatmapBuilder
   module ValueConversion
     private

--- a/lib/heatmap_builder/version.rb
+++ b/lib/heatmap_builder/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HeatmapBuilder
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
## Problem

Building SVG output emitted Ruby warnings:

```
lib/heatmap_builder/calendar.rb:269: warning: literal string will be frozen in the future
lib/heatmap_builder/calendar.rb:337: warning: literal string will be frozen in the future
lib/heatmap_builder/calendar.rb:353: warning: literal string will be frozen in the future
```

Three SVG buffers were initialized as literal empty strings (`svg = ""`) and then mutated with `<<`. Under Ruby's upcoming frozen-string-literal default those literals become frozen, so the `<<` triggers the warning today and would raise `FrozenError` once the default flips.

## Fix

Rather than just making the buffers mutable (`svg = +""`), this removes the hand-rolled string buffers entirely and builds each fragment list with `map`/`flat_map`/`filter_map` + `join` — the same idiom `#build` already uses to assemble SVG (`svg_content = []` … `.join`). This eliminates the mutable-buffer problem at the source instead of patching each instance.

- `calendar_cells_svg` → `flat_map { … map { render_cell … } }.join`
- `day_labels_svg` → `map.with_index { svg_text … }.join`
- `month_labels_svg` → `filter_map { month_label_at … if first_of_month }.join`
- Add `# frozen_string_literal: true` to every file under `lib/`.
- Bump version `0.4.3` → `0.4.4` + CHANGELOG entry.

## Verification

- `bundle exec rake test` → 54 runs, 112 assertions, 0 failures, 0 errors. The suite includes snapshot tests comparing exact SVG output, so this confirms **byte-identical** output.
- `RUBYOPT="--enable-frozen-string-literal" bundle exec rake test` → 0 warnings, 0 errors; the three `calendar.rb` warnings are gone.
- `bundle exec rake standard` → pass.

## Release / downstream

After merge, tag `v0.4.4` so consumers (e.g. F2) can pick it up via `bundle update heatmap-builder` — no consumer code change needed beyond the lockfile bump.